### PR TITLE
fix admin selector in setting suggestion icon

### DIFF
--- a/cypress/support/navigate.js
+++ b/cypress/support/navigate.js
@@ -12,7 +12,7 @@ export const navigateToAdmin = () => {
         .should('be.visible')
         .click({ force: true });
 
-    cy.get('[data-testid="AdminPanelSettingsIcon"]', { timeout: TIMEOUT })
+    cy.get('li[role="menuitem"] [data-testid="AdminPanelSettingsIcon"]', { timeout: TIMEOUT })
         .should('exist')
         .should('be.visible')
         .click({ force: true });


### PR DESCRIPTION
### Overview
The admin navigation helper was intermittently clicking the wrong element after a recent push release added another element using the same data-testid="AdminPanelSettingsIcon" in the side panel. Our previous selector was too broad and would match the new icon, causing the script to navigate to the Settings Suggestion instead of the Admin Settings.

### 🔧 What’s fixed
File updated: [navigate.js](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Selector in navigateToAdmin() now scopes the lookup to a menu item, ensuring we target the icon inside the drop‑down menu rather than the side panel:

### ✅ Why this matters
Avoids false clicks on the settings suggestion icon introduced in the latest release.
Stabilises admin‑panel navigation in tests by being more specific about element location.


Create Organization script is now PASSED ✅ 
<img width="1865" height="993" alt="Screenshot 2026-03-13 at 1 43 37 PM" src="https://github.com/user-attachments/assets/e7ec6749-1d66-4c20-a9b5-2a13c18c0758" />
