### PR TITLE
fix: rename Software Engineering to Software Lifecycle Engineering

### DIFF
--- a/cypress/fixtures/data.json
+++ b/cypress/fixtures/data.json
@@ -61,12 +61,12 @@
         ],
         "specificNavItems": {
             "AI Platforms": "Market Forecast",
-            "Software Engineering": "DevOps Market",
+            "Software Lifecycle Engineering": "DevOps Market",
             "Cybersecurity": "Forecast Overview"
         },
         "expectedTiles": {
             "AI Platforms": "Market Scenario Assumptions",
-            "Software Engineering": "2025 Revenue",
+            "Software Lifecycle Engineering": "2025 Revenue",
             "Cybersecurity": "Market Segment"
         }
     },

--- a/cypress/support/exportdata.js
+++ b/cypress/support/exportdata.js
@@ -1,4 +1,4 @@
-const PracticeArea = ['AI Platforms','Cybersecurity','Semiconductors','Software Engineering','Enterprise Software','CIO Insights','CEO Insights','AI Devices','Channel Ecosystems']; // Add Practice Areas here - no data yet (Customer Experience, Quantum Computing, Communications Network, Data Intelligence,) - Customer Portal has its own Export Data.
+const PracticeArea = ['AI Platforms','Cybersecurity','Semiconductors','Software Lifecycle Engineering','Enterprise Software','CIO Insights','CEO Insights','AI Devices','Channel Ecosystems']; // Add Practice Areas here - no data yet (Customer Experience, Quantum Computing, Communications Network, Data Intelligence,) - Customer Portal has its own Export Data.
 
 const getRandomPracticeArea = (count) => {
     return PracticeArea.sort(() => 0.5 - Math.random()).slice(0, count);
@@ -52,7 +52,7 @@ const practiceAreaConfig = {
             { path: 'cypress/downloads/Strategic Investments.csv', content: 'Europe - Western Europe/EU' }
         ]
     },
-    'Software Engineering': {
+    'Software Lifecycle Engineering': {
         exports: [
             { xpath: "(//span[contains(text(),'Export')])[2]", wait: 5000 },
             { xpath: "(//span[contains(text(),'Export')])[3]", wait: 10000 },

--- a/cypress/support/migration.js
+++ b/cypress/support/migration.js
@@ -10,7 +10,7 @@ const CONFIG = {
         'Send Email to Users',
         'Customer Portal',
         'CyberSecurity',
-        'Software Engineering',
+        'Software Lifecycle Engineering',
         'CIO Insights',
         'AI Devices',
         'Data Intelligence',


### PR DESCRIPTION
## Summary
- Updated practice area name from "Software Engineering" to "Software Lifecycle Engineering" across all test files to match the app's updated label

## Files Changed
- `cypress/support/exportdata.js` — updated PracticeArea array and config key
- `cypress/support/migration.js` — updated CHECKBOXES array
- `cypress/fixtures/data.json` — updated specificNavItems and expectedTiles keys