### PR TITLE
fix: move ngrok to optional dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "http-server": "^14.1.1",
     "mochawesome": "^7.1.3",
     "mochawesome-merge": "^4.4.1",
-    "mochawesome-report-generator": "^6.2.0",
-    "ngrok": "^5.0.0-beta.2"
+    "mochawesome-report-generator": "^6.2.0"
   },
   "main": "cypress.config.js",
   "dependencies": {
@@ -192,6 +191,9 @@
     "wrap-ansi": "^7.0.0",
     "wrappy": "^1.0.2",
     "yauzl": "^2.10.0"
+  },
+  "optionalDependencies": {
+    "ngrok": "^5.0.0-beta.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Summary
Fixes install breakages caused by ngrok failing to install in some environments by moving it from devDependencies to optionalDependencies.

### Changes
package.json: remove ngrok from devDependencies, add it under optionalDependencies.

### Behavior/Impact
npm install can succeed even if ngrok can’t be installed; test runs that don’t require ngrok are unblocked.