### PR TITLE
Fix/email num users

### DIFF
--- a/cypress/support/emailJobs.js
+++ b/cypress/support/emailJobs.js
@@ -447,7 +447,7 @@ class EmailJobs {
                 
                 // Verify user counts
                 verifyOrganizationUserCount(org2, 8);
-                verifyOrganizationUserCount(org3, 4);
+                verifyOrganizationUserCount(org3, 2);
             });
         });
 

--- a/cypress/support/emailJobs.js
+++ b/cypress/support/emailJobs.js
@@ -264,7 +264,7 @@ const selectOrganizationFromSendingSummary = (organization) => {
 };
     
 const verifyOrganizationShowUp = (organization) => {
-    cy.contains('Send to All Users in 2 Organizations', { timeout: TIMEOUT })
+    cy.contains('button', 'Send to All Users in 2 Organizations', { timeout: TIMEOUT })
         .scrollIntoView()
         .should('exist')
         .should('be.visible')
@@ -434,7 +434,7 @@ class EmailJobs {
                 selectOrganizationFromSendingSummary(org3);
                 
                 // Click to open modal
-                cy.contains('Send to All Users in 2 Organizations', { timeout: TIMEOUT })
+                cy.contains('button', 'Send to All Users in 2 Organizations', { timeout: TIMEOUT })
                     .scrollIntoView()
                     .should('exist')
                     .should('be.visible')


### PR DESCRIPTION
### PR Summary

Fixes the “Number of users” validation in Email Jobs by targeting the correct UI element and updating the expected user count for aws_qa.

### What Changed
cypress/support/emailJobs.js: scopes cy.contains() to the button (“Send to All Users in 2 Organizations”) to avoid matching the wrong element.
cypress/support/emailJobs.js: updates expected user count for org3 from 4 → 2 (aws_qa org).