### PR TITLE
Updated redirection URL check and login each pwd change

### DIFF
--- a/cypress/e2e/UserPassword.cy.js
+++ b/cypress/e2e/UserPassword.cy.js
@@ -1,15 +1,6 @@
-import { login2 } from '../support/login.js';
 import Users from '../support/Users.js';
 
 describe('User Password Change Tests', () => {
-    
-    beforeEach(() => {
-        cy.fixture('accounts.json').then((accounts) => {
-            const { username, password } = accounts.existingUsers.resetPasswordUser
-            login2(username, password);
-        });
-        
-    });
 
     describe('Reset Password', () => {
         Users.resetPassword('chadtest09231', 'NewPassword123!', 'Testing12345!');

--- a/cypress/support/Users.js
+++ b/cypress/support/Users.js
@@ -239,10 +239,16 @@ class Users {
 
     static resetPassword(username, newPassword, originalPassword) {
         it('Change user password', () => {
+            // Login with the current (original) password before changing it
+            login2(username, originalPassword);
+            cy.wait(2000);
             changePassword(username, newPassword, originalPassword);
         });
         it('Revert password back to original', () => {
-            // Need to re-authenticate after previous test changed password
+            // Cypress clears session between tests — must login with the new password
+            // that was set by the previous test before reverting
+            login2(username, newPassword);
+            cy.wait(3000);
             changePassword(username, originalPassword, newPassword);
         });
     }

--- a/cypress/support/login.js
+++ b/cypress/support/login.js
@@ -86,11 +86,12 @@ export function login(username, password, forceLogout = false) {
                 
                 // Verify successful login after logging in
                 cy.url({ timeout: 30000 }).should('satisfy', (url) => {
-                    return url.includes('/feed') || 
-                           url.includes('/home') || 
-                           url.includes('/account_overview') || 
-                           url.includes('/md_executive_summary') || 
-                           url.includes('/analyst_home');
+                    return url.includes('/feed') ||
+                           url.includes('/home') ||
+                           url.includes('/account_overview') ||
+                           url.includes('/md_executive_summary') ||
+                           url.includes('/analyst_home') ||
+                           url.includes('/customerHome');
                 });
             }
             else if (url.includes('/login') || hasLoginForm) {
@@ -110,11 +111,12 @@ export function login(username, password, forceLogout = false) {
                 
                 // Verify successful login after logging in
                 cy.url({ timeout: 30000 }).should('satisfy', (url) => {
-                    return url.includes('/feed') || 
-                           url.includes('/home') || 
-                           url.includes('/account_overview') || 
-                           url.includes('/md_executive_summary') || 
-                           url.includes('/analyst_home');
+                    return url.includes('/feed') ||
+                           url.includes('/home') ||
+                           url.includes('/account_overview') ||
+                           url.includes('/md_executive_summary') ||
+                           url.includes('/analyst_home') ||
+                           url.includes('/customerHome');
                 });
             } else {
                 cy.log('Already logged in with correct user, skipping login flow');
@@ -154,11 +156,12 @@ export function login2(username, password) {
                 
                 // Verify successful login after logging in
                 cy.url({ timeout: 30000 }).should('satisfy', (url) => {
-                    return url.includes('/feed') || 
-                           url.includes('/home') || 
-                           url.includes('/account_overview') || 
-                           url.includes('/md_executive_summary') || 
-                           url.includes('/analyst_home');
+                    return url.includes('/feed') ||
+                           url.includes('/home') ||
+                           url.includes('/account_overview') ||
+                           url.includes('/md_executive_summary') ||
+                           url.includes('/analyst_home') ||
+                           url.includes('/customerHome');
                 });
             } else {
                 cy.log('Already logged in, skipping login flow');


### PR DESCRIPTION
**Fix: UserPassword and Users test failures caused by session and URL assertion issues**

---

**Problem**

**1. `Users.cy.js` — `Remove user subscription` failing in `beforeEach` (+ 3 downstream skips)**
The login URL assertion in `login.js` only accepted `/feed`, `/home`, `/account_overview`, `/md_executive_summary`, and `/analyst_home` as valid post-login destinations. The `resetPasswordUser` account (`chadtest09231`) lands on `/customerHome/customer_home` after login, causing a 30s timeout on every `beforeEach` hook and skipping the entire `User Subscription Tests` suite.

**2. `UserPassword.cy.js` — `Revert password back to original` always failing**
Cypress 12+ clears cookies and localStorage between every `it` block (`testIsolation: true` default). After Test 1 changed the password to `NewPassword123!`, the session was wiped. The `beforeEach` then attempted to log in with the original password (`Testing12345!`), which was now invalid, resulting in a broken/unauthenticated session. The Change Password form submission was rejected (401s) and the success toast never appeared.

---

**Changes**

- **`login.js`** — Added `/customerHome` to the accepted post-login URL list in all three assertions (`login` × 2 and `login2` × 1)
- **`UserPassword.cy.js`** — Removed the `beforeEach` login block; it was redundant since `changePassword` already handles its own logout/re-login cycle
- **`Users.js`** — Each test in `resetPassword` now explicitly logs in with the correct current password before executing: Test 1 uses `originalPassword`, Test 2 uses `newPassword` (what Test 1 set it to), plus a 3s wait before the revert to allow the server to settle between consecutive password changes on the same account
