### PR TITLE
Fix profile selector, fixture and org3 user count

### DIFF
--- a/cypress/fixtures/data.json
+++ b/cypress/fixtures/data.json
@@ -106,8 +106,7 @@
             "cleo 1 (cleo+1@milliononmars.com)"
         ],
         "org3Users": [
-            "julie+110b (julie+110b@milliononmars.com)",
-            "Terry Farmer (tfarmer+2@futurumgroup.com)"
+            "julie+110b (julie+110b@milliononmars.com)"
         ]
     },
     "report": {

--- a/cypress/support/emailJobs.js
+++ b/cypress/support/emailJobs.js
@@ -3,7 +3,6 @@ const WAIT_TIMEOUT = 2000;
 
 const navigateToUserProfile = () => {
     cy.get('[data-testid="PersonIcon"]', { timeout: TIMEOUT })
-        .eq(1)
         .should('exist')
         .click({ force: true });
     cy.contains('Profile', { timeout: TIMEOUT })
@@ -447,7 +446,7 @@ class EmailJobs {
                 
                 // Verify user counts
                 verifyOrganizationUserCount(org2, 8);
-                verifyOrganizationUserCount(org3, 2);
+                verifyOrganizationUserCount(org3, 1);
             });
         });
 

--- a/cypress/support/emailTemplates.js
+++ b/cypress/support/emailTemplates.js
@@ -2,7 +2,6 @@ const TIMEOUT = 10000;
 
 const navigateToUserProfile = () => {
     cy.get('[data-testid="PersonIcon"]', { timeout: TIMEOUT })
-        .eq(1) // Select the second occurrence
         .should('exist')
         .click({ force: true });
     cy.contains('Profile', { timeout: TIMEOUT })


### PR DESCRIPTION
Remove hard-coded .eq(1) index from navigateToUserProfile in emailJobs.js and emailTemplates.js to avoid selecting the wrong PersonIcon. Remove duplicate Terry Farmer entry from cypress/fixtures/data.json and update the org3 user count assertion from 2 to 1 in emailJobs.js so tests match the fixture data.