### PR TITLE
Updated login check

### DIFF
--- a/cypress/support/Users.js
+++ b/cypress/support/Users.js
@@ -248,6 +248,8 @@ class Users {
             // Cypress clears session between tests — must login with the new password
             // that was set by the previous test before reverting
             login2(username, newPassword);
+            // Wait for authenticated UI to confirm session is fully ready before proceeding
+            cy.get('[data-testid="PersonIcon"]', { timeout: 15000 }).should('be.visible');
             cy.wait(3000);
             changePassword(username, originalPassword, newPassword);
         });


### PR DESCRIPTION
**Fix: Revert password test failing due to session not fully initialized after login**

---

**Problem**

The `Revert password back to original` test was failing with `POST 401 /api/password/change` on every attempt. Screenshots confirmed that all background API calls (`/api/app-files/reports`, `/api/settings/nav-order/fetch`) were also returning 401 by the time the profile page loaded — meaning the session was not fully active when `navigateToUserProfile()` fired.

The root cause was that `login2`'s URL assertion passes the moment the URL changes, but the app continues initializing the session in the background. The previous `cy.wait(3000)` was not enough time, causing `changePassword` to run before the auth token was ready.

---

**Changes**

- **`Users.js`** — Replaced the fixed `cy.wait(3000)` in the revert test with a `cy.get('[data-testid="PersonIcon"]', { timeout: 15000 }).should('be.visible')` check before the wait. `PersonIcon` is part of the authenticated UI and only renders when the session is fully active, making it a reliable signal that the app is ready to accept authenticated API calls
