### PR TITLE
fix: adjust GenAI actual response latency threshold (60s → 120s)

### DIFF
--- a/cypress.env.json
+++ b/cypress.env.json
@@ -3,7 +3,7 @@
     "genAI": {
         "latencyThresholds": {
             "initialResponseLatency": "15", 
-            "actualResponseLatency": "60"
+            "actualResponseLatency": "120"
         }
     }
 }


### PR DESCRIPTION

### Summary
Updates Cypress GenAI latency config to accommodate slower responses after the DeepSearch update and reduce flaky failures.

### Changes
cypress.env.json: genAI.latencyThresholds.actualResponseLatency increased from "60" to "120".
