### PR TITLE
fix: update org selectors

### DIFF
--- a/cypress/support/accounts-org.js
+++ b/cypress/support/accounts-org.js
@@ -41,8 +41,13 @@ const updateOrg = (NewOrgName) => {
 
 const linkSalesforce = () => {
 
-    cy.get('.css-1g5jyb9', {timeout: TIMEOUT})
-        .should('exist').click().type('Acme');
+    // cy.get('.css-1g5jyb9', {timeout: TIMEOUT})
+    //     .should('exist').click().type(OrgName);
+    cy.contains('label', 'Link Salesforce Account')
+        .parent()
+        .find('input[role="combobox"]')
+        .clear()
+        .type('Acme (Sample)');
     cy.contains('Acme (Sample)', {matchCase: false, timeout: TIMEOUT})
         .should('exist')
         .click()
@@ -83,7 +88,8 @@ const removeSubscription = () => {
 }
 
 const deleteOrg = (OrgName) => {
-    cy.get('.css-1lv7pyi')
+    cy.get('input[value="all"]')
+        .clear()
         .type(OrgName);
     cy.contains(OrgName)
         .click();

--- a/cypress/support/accounts-org.js
+++ b/cypress/support/accounts-org.js
@@ -40,9 +40,6 @@ const updateOrg = (NewOrgName) => {
 }
 
 const linkSalesforce = () => {
-
-    // cy.get('.css-1g5jyb9', {timeout: TIMEOUT})
-    //     .should('exist').click().type(OrgName);
     cy.contains('label', 'Link Salesforce Account')
         .parent()
         .find('input[role="combobox"]')


### PR DESCRIPTION
### PR Summary

- Updates fragile CSS-class selectors in org admin flows to more stable, accessible selectors.
- linkSalesforce(): targets the “Link Salesforce Account” combobox via its label/role and selects Acme (Sample).
- deleteOrg(OrgName): switches org search input selector to input[value="all"] and clears before typing.

### Files Changed

cypress/support/accounts-org.js