### PR TITLE
Updated filter dates

### DIFF
--- a/cypress/support/analytics.js
+++ b/cypress/support/analytics.js
@@ -6,9 +6,10 @@ const DEFAULT_TIMEOUT = 15000;
 // Create reusable constants
 const ANALYTICS_CONFIG = {
     ORGANIZATION: 'ChadOrg_QAs',
-    EMAIL: 'chad@milliononmars.com',
-    START_DATE: '2025-11-03',
-    END_DATE: '2025-11-03',
+    EMAIL: 'QA-AUT@milliononmars.com',
+    EMAIL2: 'chad@milliononmars.com',
+    START_DATE: '2026-03-11',
+    END_DATE: '2026-03-11',
     RESULTS_DATE: '2025-10-01',
     MIN_COUNT_VALUE: 1,
 };
@@ -54,7 +55,7 @@ const validateEmails = () => {
     // Input Email
     cy.get('input[placeholder="Search by email..."]', { timeout: DEFAULT_TIMEOUT })
         .should('be.visible')
-        .type(ANALYTICS_CONFIG.EMAIL);
+        .type(ANALYTICS_CONFIG.EMAIL2);
 
     //select start date
     cy.get('input[type="date"]').first()


### PR DESCRIPTION
## Summary
- Updated `START_DATE` and `END_DATE` to `2026-03-11` to reflect a valid filter window that returns results
- Split email config into `EMAIL` (QA-AUT@milliononmars.com) and `EMAIL2` (chad@milliononmars.com) so each test targets the correct account
- Fixed `validateEmails` to use `EMAIL2` (chad@milliononmars.com) — previously it incorrectly used `EMAIL`

## Files Changed
- `cypress/support/analytics.js`

## Test Coverage
- Analytics > Should navigate to Emails and validate count
