### PR TITLE
fix: stabilize Cypress login navigation by increasing post-visit wait

### DIFF
--- a/cypress/support/data.js
+++ b/cypress/support/data.js
@@ -1,4 +1,4 @@
-const QA = ['Acme_QA','AMD_QA', 'AWS_QA', 'Broadcom_QA', 'ChadOrg_QA, Inc_QA', 'Cloudera_QA', 'Commvault_QA', 'DELL_QA', 'ElasticSearch_QA', 'Google_QA', 'GoTo_QA', 'Groq', 'HPE_QA', 'HPE_QA', 'IBM_QA', 'Intel_QA', 'JulOrg_Test', 'Lattice_QA', 'Lenovo_QA', 'Logitech_QA', 'Marvell_QA', 'Microsoft', 'NetApp_QA', 'Oracle_QA', 'PureStorage_QA', 'Qualcomm_QA', 'Salesforce_QA', 'ServiceNow_QA', 'Shure_QA', 'SmartSheet_QA', 'Synopsis_QA', 'Veeam_QA', 'Zoho_QA', 'Zoom_QA']; // Add your qas here
+const QA = ['AMD_QA', 'AWS_QA', 'Broadcom_QA', 'ChadOrg_QA, Inc_QA', 'Cloudera_QA', 'Commvault_QA', 'ElasticSearch_QA', 'Google_QA', 'GoTo_QA', 'Groq', 'HPE_QA', 'HPE_QA', 'IBM_QA', 'Intel_QA', 'JulOrg_Test', 'Lattice_QA', 'Lenovo_QA', 'Logitech_QA', 'Marvell_QA', 'Microsoft', 'NetApp_QA', 'Oracle_QA', 'PureStorage_QA', 'Qualcomm_QA', 'Salesforce_QA', 'ServiceNow_QA', 'Shure_QA', 'SmartSheet_QA', 'Synopsis_QA', 'Veeam_QA', 'Zoho_QA', 'Zoom_QA']; // Add your qas here
 const exclude = ['Logitech_QA', 'ChadOrg_QA, Inc_QA'];
 const filteredQA = QA.filter(q => !exclude.includes(q));
 

--- a/cypress/support/login.js
+++ b/cypress/support/login.js
@@ -2,7 +2,8 @@ export function login(username, password, forceLogout = false) {
     // Visit the Polaris URL
     cy.visit(Cypress.env('appUrl'))
 
-    cy.wait(5000);
+    cy.document().its('readyState').should('eq', 'complete');
+    cy.wait(10000);
 
     // Wait for the page to load and check if we're on the login page
     cy.url().then((url) => {


### PR DESCRIPTION
### Summary

- Increases the wait after navigating to the app to account for a brief blank/white screen before the login page renders, reducing flaky failures during login. (cypress/support/login.js:5, cypress/support/login.js:6)
- Adds a simple page readiness check (document.readyState === "complete") before the longer wait to avoid racing the initial load. (cypress/support/login.js:5)
- Also included in this branch: updates the QA org list (removes some entries) in support data. If unrelated, consider splitting into a separate PR. (cypress/support/data.js:1)

### Notes / Tradeoff

This is a pragmatic stability tweak (slower by ~5s per login) to reduce effort while we migrate tests to Playwright.