### PR TITLE
fix: handle white page to reduce flaky tests

### DIFF
--- a/cypress/support/login.js
+++ b/cypress/support/login.js
@@ -2,7 +2,23 @@ export function login(username, password, forceLogout = false) {
     // Visit the Polaris URL
     cy.visit(Cypress.env('appUrl'))
 
+    cy.document().its('readyState').should('eq', 'complete');
     cy.wait(5000);
+
+    // Check for white page - retry up to 5 times if page lacks expected content
+    const checkForContent = (attempt = 1) => {
+        cy.get('body').then(($body) => {
+            const hasContent = $body.text().includes('Futurum') || $body.text().includes('Practice Areas');
+            if (!hasContent && attempt < 5) {
+                cy.log(`White page detected (attempt ${attempt}/5), waiting 5 seconds...`);
+                cy.wait(5000);
+                checkForContent(attempt + 1);
+            } else if (!hasContent) {
+                cy.log('Expected page content not found after 5 attempts, proceeding...');
+            }
+        });
+    };
+    checkForContent();
 
     // Wait for the page to load and check if we're on the login page
     cy.url().then((url) => {


### PR DESCRIPTION
### Summary

- Added a document.readyState check in login() to ensure the page has fully loaded before proceeding
- Added a checkForContent() retry loop in login() that detects white/blank page renders by checking for expected page content ("Futurum" or "Practice Areas")
- The loop retries up to 5 times with a 5-second wait between each attempt before proceeding

### Problem
After cy.visit(), the app occasionally rendered a white/blank page due to a slow or failed React hydration. This caused downstream login checks to fail intermittently, producing flaky test results.

### Solution
Before cy.url().then() evaluates the login state, a recursive Cypress retry function now verifies the page has rendered expected content. If the page is blank, it waits 5 seconds and rechecks — up to 5 times — giving the app time to recover without failing the test outright.

### Files Changed
[cypress/support/login.js](vscode-webview://0qjjbq3q4fcn5chj0tj752teeigr54qsmgnlv3hidlbdqp0118vq/cypress/support/login.js) — added readyState check and checkForContent() retry logic in the login() function