### PR TITLE
Update fixtures and adjust emailJobs tests

### DIFF
--- a/cypress/fixtures/data.json
+++ b/cypress/fixtures/data.json
@@ -74,20 +74,18 @@
         "name": "monthly IBM emails",
         "organization": "AMD_QA (3 users)",
         "org1": "AMD_QA",
-        "org2": "Acme_QA",
-        "org3": "AWS_QA",
+        "org2": "Automation Organization",
+        "org3": "Automation Organization 2",
         "emailJobName": "July 2025 Kevin",
         "emailJobName2": "Automation Test",
-        "user1": "chad+test03180",
+        "user1": "Chad Test05142",
         "userEmails": [
-            "chad+test03180@milliononmars.com",
-            "kevin+cypress@milliononmars.com"
+            "chad+test05142@milliononmars.com",
+            "Chad Test0509 (chad+test0509@milliononmars.com)"
         ],
         "alluseremails": [
-            "chad+test03180@milliononmars.com",
-            "kevin+cypress@milliononmars.com",
-            "allan@milliononmars.com",
-            "poy@milliononmars.com"
+            "chad+test05142@milliononmars.com",
+            "chad+test0509@milliononmars.com"
         ],
         "allorgnames": [
             "AMD_QA",
@@ -96,17 +94,16 @@
             "Arm_QA"
         ],
         "org2Users": [
-            "chad+test03180 (chad+test03180@milliononmars.com)",
-            "allan (allan@milliononmars.com)",
-            "Poy (poy@milliononmars.com)",
-            "Kevin Cypress (kevin+cypress@milliononmars.com)",
-            "chad+test102111 (chad+test102111@milliononmars.com)",
-            "chad+test102115 (chad+test102115@milliononmars.com)",
-            "chad+test102116 (chad+test102116@milliononmars.com)",
-            "cleo 1 (cleo+1@milliononmars.com)"
+            "Chad Test05142 (chad+test05142@milliononmars.com)",
+            "Chad Test0514 (chad+test05141@milliononmars.com)",
+            "Chad Test0509 (chad+test0509@milliononmars.com)"
         ],
         "org3Users": [
-            "julie+110b (julie+110b@milliononmars.com)"
+            "Chad Test0802 (chad+test0802@gmail.com)",
+            "Chad test080724 (chad+test080724@milliononmars.com)",
+            "chad+test021402 (chad+test021402@milliononmars.com)",
+            "chad+test102101 (chad+test102101@milliononmars.com)",
+            "chad+test102102 (chad+test102102@milliononmars.com)"
         ]
     },
     "report": {

--- a/cypress/support/emailJobs.js
+++ b/cypress/support/emailJobs.js
@@ -159,21 +159,15 @@ const selectOrganizationFromChecklist = (organization) => {
 };
 
 const clickDropdownAndWait = (dropdownText, waitTime = 800) => {
-    cy.contains(dropdownText, { timeout: TIMEOUT })
+    cy.contains('button[role="combobox"]', dropdownText, { timeout: TIMEOUT })
         .scrollIntoView()
         .should('exist')
-        .should('be.visible')
         .click({ force: true });
 
     cy.wait(waitTime);
 
-    cy.get('ul[role="listbox"]', { timeout: TIMEOUT })
-        .should('exist')
-        .should('be.visible');
-
     cy.get('li[role="option"]', { timeout: TIMEOUT })
-        .should('have.length.at.least', 1)
-        .should('be.visible');
+        .should('have.length.at.least', 1);
 };
 
 const verifyOrganizationChecklist = () => {
@@ -217,8 +211,7 @@ const verifyUserDropdownLoads = (userLabel, userEmails) => {
     userEmails.forEach((email) => {
         cy.get('li[role="option"]', { timeout: TIMEOUT })
             .contains(email)
-            .should('exist')
-            .should('be.visible');
+            .should('exist');
     });
 };
 
@@ -234,7 +227,7 @@ const verifyPreviewEmailTemplate = () => {
         .should('not.be.empty')
         .then(cy.wrap)
         .find('h1')
-        .contains('The latest Futurum updates for Acme_QA')
+        .contains('The latest Futurum updates for Automation Organization')
         .should('exist')
         .should('be.visible');
 };
@@ -446,8 +439,8 @@ class EmailJobs {
                     .should('be.visible');
                 
                 // Verify user counts
-                verifyOrganizationUserCount(org2, 9);
-                verifyOrganizationUserCount(org3, 4);
+                verifyOrganizationUserCount(org2, 3);
+                verifyOrganizationUserCount(org3, 5);
             });
         });
 


### PR DESCRIPTION
data.json

- org2 → "Automation Organization", org3 → "Automation Organization 2"
- org2Users and org3Users populated with the correct display names from the UI
- user1 → "Chad Test05142", email updated to chad+test05142@milliononmars.com
- userEmails[1] → "Chad Test0509 (chad+test0509@milliononmars.com)"

emailJobs.js
- Expected user counts updated: org2 9→3, org3 4→5
- clickDropdownAndWait — changed cy.contains(dropdownText) to cy.contains('button[role="combobox"]', dropdownText) to correctly target the MUI combobox button
- Removed .should('be.visible') from listbox/option assertions (MUI portal renders a hidden duplicate that Cypress resolves to)
- Updated preview text from "The latest Futurum updates for Acme_QA" → "Automation Organization"