### PR TITLE
fix: update Dell org name and adjust latency thresholds in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -225,9 +225,9 @@ jobs:
               # Actual Latency Status
               # ---------------------------
               ACTUAL_STATUS=":white_check_mark:"
-              if awk "BEGIN {exit !($ACTUAL >= 41 && $ACTUAL <= 60)}"; then
+              if awk "BEGIN {exit !($ACTUAL >= 41 && $ACTUAL <= 120)}"; then
                 ACTUAL_STATUS=":warning:"
-              elif awk "BEGIN {exit !($ACTUAL >= 61)}"; then
+              elif awk "BEGIN {exit !($ACTUAL >= 121)}"; then
                 ACTUAL_STATUS=":x:"
               fi
 

--- a/cypress/support/data.js
+++ b/cypress/support/data.js
@@ -1,4 +1,4 @@
-const QA = ['Acme_QA','AMD_QA', 'AWS_QA', 'Broadcom_QA', 'ChadOrg_QA, Inc_QA', 'Cloudera_QA', 'Commvault_QA', 'DELL_QA', 'ElasticSearch_QA', 'Google_QA', 'GoTo_QA', 'Groq', 'HPE_QA', 'HPE_QA', 'IBM_QA', 'Intel_QA', 'JulOrg_Test', 'Lattice_QA', 'Lenovo_QA', 'Logitech_QA', 'Marvell_QA', 'Microsoft', 'NetApp_QA', 'Oracle_QA', 'PureStorage_QA', 'Qualcomm_QA', 'Salesforce_QA', 'ServiceNow_QA', 'Shure_QA', 'SmartSheet_QA', 'Synopsis_QA', 'Veeam_QA', 'Zoho_QA', 'Zoom_QA']; // Add your qas here
+const QA = ['Acme_QA','AMD_QA', 'AWS_QA', 'Broadcom_QA', 'ChadOrg_QA, Inc_QA', 'Cloudera_QA', 'Commvault_QA', 'DELL', 'ElasticSearch_QA', 'Google_QA', 'GoTo_QA', 'Groq', 'HPE_QA', 'HPE_QA', 'IBM_QA', 'Intel_QA', 'JulOrg_Test', 'Lattice_QA', 'Lenovo_QA', 'Logitech_QA', 'Marvell_QA', 'Microsoft', 'NetApp_QA', 'Oracle_QA', 'PureStorage_QA', 'Qualcomm_QA', 'Salesforce_QA', 'ServiceNow_QA', 'Shure_QA', 'SmartSheet_QA', 'Synopsis_QA', 'Veeam_QA', 'Zoho_QA', 'Zoom_QA']; // Add your qas here
 const exclude = ['Logitech_QA', 'ChadOrg_QA, Inc_QA'];
 const filteredQA = QA.filter(q => !exclude.includes(q));
 


### PR DESCRIPTION
### Summary

- Renamed DELL_QA to DELL in the QA org list in [cypress/support/data.js](vscode-webview://0qjjbq3q4fcn5chj0tj752teeigr54qsmgnlv3hidlbdqp0118vq/cypress/support/data.js) to match the correct organization name in the environment.
- Raised the latency warning threshold from 41–60 to 41–120 and the error threshold from ≥61 to ≥121 in [.github/workflows/main.yml](vscode-webview://0qjjbq3q4fcn5chj0tj752teeigr54qsmgnlv3hidlbdqp0118vq/.github/workflows/main.yml) to accommodate higher response times introduced by the DeepSeek model.
