### PR TITLE
fix: update the chad gmail test data

### DIFF
--- a/cypress/fixtures/data.json
+++ b/cypress/fixtures/data.json
@@ -99,7 +99,7 @@
             "Chad Test0509 (chad+test0509@milliononmars.com)"
         ],
         "org3Users": [
-            "Chad Test0802 (chad+test0802@gmail.com)",
+            "Chad Test0807 (chad+test0807@milliononmars.com)",
             "Chad test080724 (chad+test080724@milliononmars.com)",
             "chad+test021402 (chad+test021402@milliononmars.com)",
             "chad+test102101 (chad+test102101@milliononmars.com)",


### PR DESCRIPTION
Updated the test data for email jobs "Chad Test0802 (chad+test0802@gmail.com)", to "Chad Test0807 (chad+test0807@milliononmars.com)". The test data "Chad Test0802 (chad+test0802@gmail.com)" was changed in the Polaris Plawright migration.