### PR TITLE
fix: update AI Devices data to Intelligent Devices

### DIFF
--- a/cypress/fixtures/data.json
+++ b/cypress/fixtures/data.json
@@ -54,7 +54,7 @@
             "Cybersecurity"
         ],
         "unsubscribed": [
-            "AI Devices",
+            "Intelligent Devices",
             "Data Intelligence",
             "CEO Insights",
             "Channel Ecosystems"
@@ -65,7 +65,7 @@
             "Cybersecurity": "Forecast Overview"
         },
         "expectedTiles": {
-            "AI Platforms": "Market Scenario Assumptions",
+            "AI Platforms": "Scenario Assumptions Table",
             "Software Lifecycle Engineering": "2025 Revenue",
             "Cybersecurity": "Market Segment"
         }

--- a/cypress/support/exportdata.js
+++ b/cypress/support/exportdata.js
@@ -1,4 +1,4 @@
-const PracticeArea = ['AI Platforms','Cybersecurity','Semiconductors','Software Lifecycle Engineering','Enterprise Software','CIO Insights','CEO Insights','AI Devices','Channel Ecosystems']; // Add Practice Areas here - no data yet (Customer Experience, Quantum Computing, Communications Network, Data Intelligence,) - Customer Portal has its own Export Data.
+const PracticeArea = ['AI Platforms','Cybersecurity','Semiconductors','Software Lifecycle Engineering','Enterprise Software','CIO Insights','CEO Insights','Intelligent Devices','Channel Ecosystems']; // Add Practice Areas here - no data yet (Customer Experience, Quantum Computing, Communications Network, Data Intelligence,) - Customer Portal has its own Export Data.
 
 const getRandomPracticeArea = (count) => {
     return PracticeArea.sort(() => 0.5 - Math.random()).slice(0, count);
@@ -98,7 +98,7 @@ const practiceAreaConfig = {
             { path: 'cypress/downloads/Execution.csv', content: 'North America' }
         ]
     },
-    'AI Devices': {
+    'Intelligent Devices': {
         exports: [
             { xpath: "(//span[contains(text(),'Export')])[2]", wait: 5000 }
         ],

--- a/cypress/support/migration.js
+++ b/cypress/support/migration.js
@@ -12,7 +12,7 @@ const CONFIG = {
         'CyberSecurity',
         'Software Lifecycle Engineering',
         'CIO Insights',
-        'AI Devices',
+        'Intelligent Devices',
         'Data Intelligence',
         'AI Platforms',
         'Semiconductors',


### PR DESCRIPTION
### PR Summary (Branch: fix/smoke-test-failure-data-and-practice-area)

- Fixes smoke-test failures caused by a Practice Area rename from AI Devices → Intelligent Devices, and updates one expected tile label for AI Platforms.
- Updates fixtures and support helpers so exports/migration configs match current UI/data.

### Changes

- cypress/fixtures/data.json: replace AI Devices with Intelligent Devices; update AI Platforms expected tile text to Scenario Assumptions Table.
- cypress/support/exportdata.js: rename practice area entry and config key to Intelligent Devices.
- cypress/support/migration.js: update practice area list to Intelligent Devices.

### Testing

- No new tests added; change is test-data/config alignment (verify by running the affected smoke/specs in CI or locally).